### PR TITLE
adding rich nav indexing as a GitHub Action

### DIFF
--- a/.github/workflows/richcodenav.yml
+++ b/.github/workflows/richcodenav.yml
@@ -1,0 +1,19 @@
+name: RichNavigationIndexing
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  richnav:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+    - name: Install dependencies
+      run: yarn --frozen-lockfile
+    - uses: microsoft/RichCodeNavIndexer@master
+      with:
+        languages: typescript


### PR DESCRIPTION
This is a change to introduce the Rich Code Navigation indexing service to your repository and [here is our wiki](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/2340/Rich-Code-Navigation-Docs).
Adding rich navigation will allow you to navigate through remotely-hosted code without checking them out (eg. when reviewing PRs or browsing remote branches). This RichNav GitHub Action does the indexing without interfering with the official build CI.